### PR TITLE
Upload file working on the backend

### DIFF
--- a/server/app/configure/parsing-middleware.js
+++ b/server/app/configure/parsing-middleware.js
@@ -3,7 +3,6 @@ var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
 
 module.exports = function (app) {
-
     // Important to have this before any session middleware
     // because what is a session without a cookie?
     // No session at all.
@@ -12,5 +11,5 @@ module.exports = function (app) {
     // Parse our POST and PUT bodies.
     app.use(bodyParser.json());
     app.use(bodyParser.urlencoded({ extended: true }));
-
+    app.use(bodyParser.raw()); // for files
 };

--- a/server/app/routes/videos/index.js
+++ b/server/app/routes/videos/index.js
@@ -1,14 +1,15 @@
-var ffmpeg = require('fluent-ffmpeg');
-var Video = require('mongoose').model('Video');
+// utilities
 var spawn = require('child_process').spawn;
 var fs = require('fs');
 var path = require('path');
-var bodyParser = require('body-parser');
+var ffmpeg = require('fluent-ffmpeg');
 
-var express = require('express');
-var router = express.Router();
+// express and models
+var router = require('express').Router();
+var Video = require('mongoose').model('Video');
+
+// multer file handling
 var multer = require('multer');
-var fs = require('fs');
 var storage = multer.diskStorage({
     destination: function (req,file,cb){
       cb(null, path.join(__dirname, "..","..","..","temp"));
@@ -23,13 +24,10 @@ var storage = multer.diskStorage({
         });
     }
 });
-
 var upload = multer({ storage: storage });
-router.use(bodyParser.raw());
+
 
 //var command = ffmpeg(fs.createReadStream(path.join(__dirname, 'IMG_2608.MOV')));
-
-//app.use(express.static(__dirname + '/flowplayer'));
 
 
 var filters = {

--- a/server/app/routes/videos/index.js
+++ b/server/app/routes/videos/index.js
@@ -1,4 +1,5 @@
 var ffmpeg = require('fluent-ffmpeg');
+var User = require('mongoose').model('User');
 var Video = require('mongoose').model('Video');
 var spawn = require('child_process').spawn;
 
@@ -15,7 +16,13 @@ var storage = multer.diskStorage({
       cb(null, path.join(__dirname, "..","..","..","temp"));
     },
     filename: function (req,file,cb){
-      cb(null, file.originalname);
+      var parsedFile = path.parse(file.originalname);
+      var video = {title: parsedFile.name, ext: parsedFile.ext};
+      if (req.user) video.editor = req.user._id; // if user is not logged in, we won't remember who uploaded the video. sorry.
+      Video.create(video)
+        .then(function (created) {
+          cb(null, created._id+parsedFile.ext);
+        });
     }
 });
 
@@ -89,36 +96,40 @@ router.post('/download', function(req, res){
 });
 
 
-router.post('/upload', upload.single('uploadedFile'),function(req,res,next){
-    var outName = req.file.originalname.split('.')[0]+".mp4";
-    var outPath = path.join(__dirname,"../../../files");
-    var proc = ffmpeg(req.file.path)
-      .on('end', function() {
-        console.log('file has been converted succesfully, creating video in Mongo...');
-        Video.create({
-          fileName: outName,
-          path: outPath,
-          editor: req.user._id
-        }).then(function(vid){
-          if (!req.session.videoPaths) req.session.videoPaths = [vid.path+vid.fileName];
-          else req.session.videoPaths.push(vid.path+vid.fileName);
-          console.log(req.session.videoPaths);
-          res.status(201).json(vid._id);
-        }, function(err){
-          console.log(err);
-          res.json(err);
-        });
-        // if(req.file.originalname.split('.')[0]!==".webm"){           <---- for sending a file back if it wasn't webm
+// router.post('/upload', upload.single('uploadedFile'),function(req,res,next){
+//     var outName = req.file.originalname.split('.')[0]+".mp4";
+//     var outPath = path.join(__dirname,"../../../files");
+//     var proc = ffmpeg(req.file.path)
+//       .on('end', function() {
+//         console.log('file has been converted succesfully, creating video in Mongo...');
+//         Video.create({
+//           fileName: outName,
+//           path: outPath,
+//           editor: req.user._id
+//         }).then(function(vid){
+//           if (!req.session.videoPaths) req.session.videoPaths = [vid.path+vid.fileName];
+//           else req.session.videoPaths.push(vid.path+vid.fileName);
+//           console.log(req.session.videoPaths);
+//           res.status(201).json(vid._id);
+//         }, function(err){
+//           console.log(err);
+//           res.json(err);
+//         });
+//         // if(req.file.originalname.split('.')[0]!==".webm"){           <---- for sending a file back if it wasn't webm
 
-        // }
-      })
-      .on('error', function(err) {
-        console.log('an error happened: ' + err.message);
-      })
-      .inputOptions(['-strict experimental','-preset ultrafast','-vcodec libx264'])
-      .output(path.join(outPath,outName))
-      .run();
+//         // }
+//       })
+//       .on('error', function(err) {
+//         console.log('an error happened: ' + err.message);
+//       })
+//       .inputOptions(['-strict experimental','-preset ultrafast','-vcodec libx264'])
+//       .output(path.join(outPath,outName))
+//       .run();
 
+// });
+
+router.post('/upload', upload.single('uploadedFile'), function(req, res) {
+  res.send(path.parse(req.file.filename).name);
 });
 
 module.exports = router;

--- a/server/app/routes/videos/index.js
+++ b/server/app/routes/videos/index.js
@@ -1,8 +1,6 @@
 var ffmpeg = require('fluent-ffmpeg');
-var User = require('mongoose').model('User');
 var Video = require('mongoose').model('Video');
 var spawn = require('child_process').spawn;
-
 var fs = require('fs');
 var path = require('path');
 var bodyParser = require('body-parser');

--- a/server/db/models/video.js
+++ b/server/db/models/video.js
@@ -2,19 +2,17 @@ var mongoose = require('mongoose');
 var path = require('path');
 
 var schema = new mongoose.Schema({
-    fileName: {
+    title: {
         type: String,
         required: true
     },
-    path: {
+    ext: {
         type: String,
-        default: path.join(__dirname, '..','..','files'),
     },
     editor: {
         type: mongoose.Schema.Types.ObjectId,
         ref: 'User'
     }
 });
-
 
 mongoose.model('Video', schema);


### PR DESCRIPTION
Before this PR, clicking the "add" button embeds the video in the browser and makes an ajax request, but the server would 500 (there was no working system to handle the file back there).

Now the ajax request triggers the following:
- A new instance of Video is created in Mongo. The Video has a title and an extension (extracted from the original filename).
- If the user was logged in at the time of the upload (recommended!) then the new Video instance will also have a reference to its User.
- The video is saved in server/temp with a filename that is based on its unique _id.
- The server sends back a response containing just the _id of the newly created video. 

Potential remaining to-dos:
- Prompt user for log-in before sending the ajax request. By nature, the app functionality is going to be pretty limited if they are not logged in anyway.
- Convert file post-save, if it's in any format other than .webm
- Broadcast event so that new video loads on desktop (for uploads happening from mobile).
