### PR TITLE
Convert non-webm videos on upload

### DIFF
--- a/server/app/routes/videos/index.js
+++ b/server/app/routes/videos/index.js
@@ -96,7 +96,7 @@ router.post('/download', function(req, res) {
 
 router.post('/upload', upload.single('uploadedFile'), function(req, res) {
     var parsedFile = path.parse(req.file.filename);
-    if (parsedFile.ext === ".webm") res.send(parsedFile.name);
+    if (parsedFile.ext === ".webm") res.status(201).send(parsedFile.name);
     else {
         var dest = req.file.destination + '/' + parsedFile.name + '.webm';
         console.log(req.file.path); // original file

--- a/server/app/routes/videos/index.js
+++ b/server/app/routes/videos/index.js
@@ -9,31 +9,34 @@ var router = require('express').Router();
 var Video = require('mongoose').model('Video');
 
 // multer file handling
+var uploadedFilesPath = path.join(__dirname, "..", "..", "..", "temp"); // make this an app.value
 var multer = require('multer');
 var storage = multer.diskStorage({
-    destination: function (req,file,cb){
-      cb(null, path.join(__dirname, "..","..","..","temp"));
+    destination: function(req, file, cb) {
+        cb(null, uploadedFilesPath);
     },
-    filename: function (req,file,cb){
-      var parsedFile = path.parse(file.originalname);
-      var video = {title: parsedFile.name, ext: parsedFile.ext};
-      if (req.user) video.editor = req.user._id; // if user is not logged in, we won't remember who uploaded the video. sorry.
-      Video.create(video)
-        .then(function (created) {
-          cb(null, created._id+parsedFile.ext);
-        });
+    filename: function(req, file, cb) {
+        var parsedFile = path.parse(file.originalname);
+        var video = { title: parsedFile.name };
+        if (req.user) video.editor = req.user._id; // if user is not logged in, we won't remember who uploaded the video. sorry.
+        Video.create(video)
+            .then(function(created) {
+                cb(null, created._id + parsedFile.ext);
+            });
     }
 });
-var upload = multer({ storage: storage });
+var upload = multer({
+    storage: storage
+});
 
 
 //var command = ffmpeg(fs.createReadStream(path.join(__dirname, 'IMG_2608.MOV')));
 
 
 var filters = {
-  grayscale: 'colorchannelmixer=.3:.4:.3:0:.3:.4:.3:0:.3:.4:.3',
-  sepia: 'colorchannelmixer=.393:.769:.189:0:.349:.686:.168:0:.272:.534:.131',
-  blur: 'boxblur=luma_radius=5:luma_power=3'
+    grayscale: 'colorchannelmixer=.3:.4:.3:0:.3:.4:.3:0:.3:.4:.3',
+    sepia: 'colorchannelmixer=.393:.769:.189:0:.349:.686:.168:0:.272:.534:.131',
+    blur: 'boxblur=luma_radius=5:luma_power=3'
 };
 
 // instructions= [
@@ -46,86 +49,71 @@ var filters = {
 // ]
 
 
-router.post('/download', function(req, res){
-  // var outPath = path.join(__dirname,"../../../files/");
-  // var finalFilePath = path.join(__dirname,"../../../files/final.avi");
-  var ffmpeg = spawn('ffmpeg', ['-i', 'server/files/snowgroomer.webm','-strict', 'experimental', '-preset', 'ultrafast', '-vcodec', 'libx264', 'server/temp/converted.mp4', '-y']);
-    ffmpeg.on('exit',function(code,signal){
-      console.log('hey!!!, done!');
-      req.resume();
-      res.end();
+router.post('/download', function(req, res) {
+    // var outPath = path.join(__dirname,"../../../files/");
+    // var finalFilePath = path.join(__dirname,"../../../files/final.avi");
+    var ffmpeg = spawn('ffmpeg', ['-i', 'server/files/snowgroomer.webm', '-strict', 'experimental', '-preset', 'ultrafast', '-vcodec', 'libx264', 'server/temp/converted.mp4', '-y']);
+    ffmpeg.on('exit', function(code, signal) {
+        console.log('hey!!!, done!');
+        req.resume();
+        res.end();
     });
     // req.connection.pipe(ffmpeg.stdin);
-  // var instructions = req.body.data;
-  // instructions.forEach(function(instruction, ind){
-  //   instruction.path = path.join(outPath,ind.toString()+'.avi');
-  // });
-  // console.log(instructions);
-  // var numClips = instructions.length;
-  // var clipsAdded = 0;
-  // var clips = [];
-  // var proc = ffmpeg()
-  //     .on('end', function() {
-  //      console.log('file has been converted succesfully');
-  //     });
-     //  .on('error', function(err) {
-     //   console.log('an error happened: ' + err.message);
-     // });
+    // var instructions = req.body.data;
+    // instructions.forEach(function(instruction, ind){
+    //   instruction.path = path.join(outPath,ind.toString()+'.avi');
+    // });
+    // console.log(instructions);
+    // var numClips = instructions.length;
+    // var clipsAdded = 0;
+    // var clips = [];
+    // var proc = ffmpeg()
+    //     .on('end', function() {
+    //      console.log('file has been converted succesfully');
+    //     });
+    //  .on('error', function(err) {
+    //   console.log('an error happened: ' + err.message);
+    // });
 
-  // instructions.forEach(function(step, index){
-  //   var duration = step.endTime-step.startTime;
-  //   var clip = ffmpeg().input(step.path)
-  //   .output(outPath+index.toString()+'.ogv')
-  //   .on('end', function(){
-  //     clips[index]=(outPath+index.toString()+'.ogv');
-  //     clipsAdded++;
-  //     if(clipsAdded===numClips){
+    // instructions.forEach(function(step, index){
+    //   var duration = step.endTime-step.startTime;
+    //   var clip = ffmpeg().input(step.path)
+    //   .output(outPath+index.toString()+'.ogv')
+    //   .on('end', function(){
+    //     clips[index]=(outPath+index.toString()+'.ogv');
+    //     clipsAdded++;
+    //     if(clipsAdded===numClips){
 
-  // //         clips.forEach(function(clipPath){
-  //   instructions.forEach(function(clip){
-  //           proc.input(clip.path);
-  //   });
+    // //         clips.forEach(function(clipPath){
+    //   instructions.forEach(function(clip){
+    //           proc.input(clip.path);
+    //   });
     // proc.input(path.join(__dirname,"../../../temp","1.mp4"));
     // proc.input(path.join(__dirname,"../../../temp","2.mp4"));
     // proc.input(path.join(__dirname,"../../../files","c.avi"));
     // proc.mergeToFile(finalFilePath);
 });
 
-
-// router.post('/upload', upload.single('uploadedFile'),function(req,res,next){
-//     var outName = req.file.originalname.split('.')[0]+".mp4";
-//     var outPath = path.join(__dirname,"../../../files");
-//     var proc = ffmpeg(req.file.path)
-//       .on('end', function() {
-//         console.log('file has been converted succesfully, creating video in Mongo...');
-//         Video.create({
-//           fileName: outName,
-//           path: outPath,
-//           editor: req.user._id
-//         }).then(function(vid){
-//           if (!req.session.videoPaths) req.session.videoPaths = [vid.path+vid.fileName];
-//           else req.session.videoPaths.push(vid.path+vid.fileName);
-//           console.log(req.session.videoPaths);
-//           res.status(201).json(vid._id);
-//         }, function(err){
-//           console.log(err);
-//           res.json(err);
-//         });
-//         // if(req.file.originalname.split('.')[0]!==".webm"){           <---- for sending a file back if it wasn't webm
-
-//         // }
-//       })
-//       .on('error', function(err) {
-//         console.log('an error happened: ' + err.message);
-//       })
-//       .inputOptions(['-strict experimental','-preset ultrafast','-vcodec libx264'])
-//       .output(path.join(outPath,outName))
-//       .run();
-
-// });
-
 router.post('/upload', upload.single('uploadedFile'), function(req, res) {
-  res.send(path.parse(req.file.filename).name);
+    var parsedFile = path.parse(req.file.filename);
+    if (parsedFile.ext === ".webm") res.send(parsedFile.name);
+    else {
+        var dest = req.file.destination + '/' + parsedFile.name + '.webm';
+        console.log(req.file.path); // original file
+        console.log(dest); // new file
+
+        var ffmpeg = spawn('ffmpeg', ['-i', req.file.path, '-c:v', 'libvpx', '-crf', '10', '-b:v', '1M', '-c:a', 'libvorbis', dest, '-y']);
+        ffmpeg.on('message',function(msg){console.log(msg); });
+        ffmpeg.on('error',function(err){console.error(err); });
+        ffmpeg.on('exit', function(code, signal) {
+            console.log('converted to .webm');
+            fs.unlink(req.file.path,function(err){
+              console.log('deleted that old file with the dumb extension');
+              req.resume();
+              res.status(201).send(parsedFile.name);              
+            });
+        });
+    }
 });
 
 module.exports = router;

--- a/server/db/models/video.js
+++ b/server/db/models/video.js
@@ -6,9 +6,6 @@ var schema = new mongoose.Schema({
         type: String,
         required: true
     },
-    ext: {
-        type: String,
-    },
     editor: {
         type: mongoose.Schema.Types.ObjectId,
         ref: 'User'


### PR DESCRIPTION
Video upload works as before, but now it also converts non-webm videos into .webm

The program takes the following steps
1. Original video is saved. This is unchanged, using multer as before.
2. Once saved to the filesystem, we check if it's .webm. 
2a. If it is .webm, we send 201 response and we are done.
2b. If it is not .webm, we convert. When conversion is done, we delete the old file. Then we send 201 and we are done. 

Note that although it seems roundabout to save non-webm files only to delete them later, we do need these files saved before we can spawn the child process that will handle the conversion. If we could figure out how to convert with node-fluent or some other library (while preserving all the config options that we need in order to maintain video quality), then maybe we could convert on the fly and save ourselves these slow and expensive writes to disk.
