### PR TITLE
Uploads working for all videos

### DIFF
--- a/browser/js/common/directives/editvids/editvids.directive.js
+++ b/browser/js/common/directives/editvids/editvids.directive.js
@@ -49,9 +49,15 @@ app.directive("editvids", function (PreviewFactory, VideoFactory) {
 			};
 
 			function attachSourceToVideo(updatedVideoElement, instructions) {
+				console.log('updatedVideoElement',updatedVideoElement);
+				console.log('instructions',instructions);
 				VideoFactory.attachVideoSource(instructions.videoSource, updatedVideoElement.id)
 				.then(() =>  {
 					updatedVideoElement.sourceAttached = true;
+					console.log('the video element got its source');
+					console.log('updatedVideoElement',updatedVideoElement);
+					console.log('and instructions, apparently', updatedVideoElement.instructions);
+					updatedVideoElement.instructions = instructions;
 					if(typeof updatedVideoElement.instructions.endTime==='undefined'){
 						updatedVideoElement.instructions.endTime = document.getElementById(updatedVideoElement.id).duration;
 					}

--- a/browser/js/common/directives/editvids/editvids.directive.js
+++ b/browser/js/common/directives/editvids/editvids.directive.js
@@ -20,13 +20,11 @@ app.directive("editvids", function (PreviewFactory, VideoFactory) {
 				}
 				else{
 					//clip is not already there, add it to the end
-					var updatedVideoElement = VideoFactory.createVideoElement(instructions.videoSource, instructions)
-					//console.log("created new video element with instructions", updatedVideoElement.instructions);
+					var updatedVideoElement = VideoFactory.createVideoElement(instructions.videoSource, instructions);
 					$scope.videos.push(updatedVideoElement);
 
 					setTimeout(()=> {
-						attachSourceToVideo(updatedVideoElement, instructions)
-						//console.log("****$scope.videos AFTER ATTACH", $scope.videos);
+						attachSourceToVideo(updatedVideoElement, instructions);
 					}, 0);
 				}
 			});
@@ -45,14 +43,9 @@ app.directive("editvids", function (PreviewFactory, VideoFactory) {
 			};
 
 			function attachSourceToVideo(updatedVideoElement, instructions) {
-				console.log('updatedVideoElement',updatedVideoElement);
-				console.log('instructions',instructions);
 				VideoFactory.attachVideoSource(instructions.videoSource, updatedVideoElement.id)
 				.then(() =>  {
 					updatedVideoElement.sourceAttached = true;
-					console.log('the video element got its source');
-					console.log('updatedVideoElement',updatedVideoElement);
-					console.log('and instructions, apparently', updatedVideoElement.instructions);
 					updatedVideoElement.instructions = instructions;
 					if(typeof updatedVideoElement.instructions.endTime==='undefined'){
 						updatedVideoElement.instructions.endTime = document.getElementById(updatedVideoElement.id).duration;

--- a/browser/js/common/directives/sourcevids/sourcevids.controller.js
+++ b/browser/js/common/directives/sourcevids/sourcevids.controller.js
@@ -1,4 +1,4 @@
-app.controller("SourceVidsCtrl", function($scope, VideoFactory, PreviewFactory, InstructionsFactory, $state, RandomVideoGenerator) {
+app.controller("SourceVidsCtrl", function ($rootScope, $scope, VideoFactory, PreviewFactory, InstructionsFactory, $state, RandomVideoGenerator) {
 
     $scope.videos = [];
 
@@ -20,16 +20,21 @@ app.controller("SourceVidsCtrl", function($scope, VideoFactory, PreviewFactory, 
     fileInput.addEventListener('change', function(e) {
         var filesArr = Array.prototype.slice.call(fileInput.files, 0);
         filesArr.forEach(function(file) {
-            var videoElement;
+            var videoElement = VideoFactory.createVideoElement();
+            $scope.videos.push(videoElement); //try putting this up here and see if we get the spinner
             VideoFactory.addVideoSource(file)
                 .then(function(videoSource) {
-                    videoElement = VideoFactory.createVideoElement(videoSource);
-                    $scope.videos.push(videoElement);
-                    $scope.$digest();
+                	videoElement.addSource(videoSource);
+                    // if it was originally a webm video, we'll want to digest
+                    // if it wasn't, there will be a digest in progress, so we need to check before doing it
+                    let phase = $rootScope.$$phase;
+                    if (phase!=="$apply" && phase!=="$digest") $scope.$digest();
                     return VideoFactory.attachVideoSource(videoSource, videoElement.id);
                 }).then(function() {
                     videoElement.sourceAttached = true;
-                    $scope.$digest();
+                    // same here as above
+                    let phase = $rootScope.$$phase;
+                    if (phase!=="$apply" && phase!=="$digest") $scope.$digest();
                 }).then(null, function(error) {
                     //TODO show error on video tag
                     console.error("Error occured when attaching video source", error);

--- a/browser/js/common/directives/sourcevids/sourcevids.controller.js
+++ b/browser/js/common/directives/sourcevids/sourcevids.controller.js
@@ -17,24 +17,6 @@ app.controller("SourceVidsCtrl", function ($scope, VideoFactory, PreviewFactory,
 		});
 	});
 
-	$scope.videos = [];
-
-	var fileInput = document.getElementById("videofileinput");
-
-	$scope.selectVideoFile = function () {
-		fileInput.click();
-	};
-
-	$scope.$on("videosource-deleted", function (event, videoSourceId) {
-		$scope.videos.some(function (videoElement, index) {
-			if (videoElement.videoSource.id === videoSourceId) {
-				$scope.videos.splice(index, 1);
-				return true;
-			}
-		});
-	});
-
-
 	fileInput.addEventListener('change', function(e) {
 		var filesArr = Array.prototype.slice.call(fileInput.files, 0);
 		filesArr.forEach(function (file) {

--- a/browser/js/common/directives/sourcevids/sourcevids.controller.js
+++ b/browser/js/common/directives/sourcevids/sourcevids.controller.js
@@ -46,7 +46,7 @@ app.controller("SourceVidsCtrl", function($rootScope, $scope, VideoFactory, Prev
 
     // This is here just for testing the preview player
     $scope.previewVideo = () => {
-        var cutsNumber = 5;
+        var cutsNumber = 4;
         var cutLength = 2;
         var allInstructions = RandomVideoGenerator.createVideo($scope.videos, cutsNumber, cutLength);
         PreviewFactory.setInstructions(allInstructions);

--- a/browser/js/common/directives/sourcevids/sourcevids.controller.js
+++ b/browser/js/common/directives/sourcevids/sourcevids.controller.js
@@ -1,52 +1,52 @@
-app.controller("SourceVidsCtrl", function ($scope, VideoFactory, PreviewFactory, InstructionsFactory, $state, RandomVideoGenerator) {
+app.controller("SourceVidsCtrl", function($scope, VideoFactory, PreviewFactory, InstructionsFactory, $state, RandomVideoGenerator) {
 
-	$scope.videos = [];
+    $scope.videos = [];
 
-	var fileInput = document.getElementById("videofileinput");
+    var fileInput = document.getElementById("videofileinput");
 
-	$scope.selectVideoFile = function () {
-		fileInput.click();
-	};
+    $scope.selectVideoFile = function() {
+        fileInput.click();
+    };
 
-	$scope.$on("videosource-deleted", function (event, videoSourceId) {
-		$scope.videos.some(function (videoElement, index) {
-			if (videoElement.videoSource.id === videoSourceId) {
-				$scope.videos.splice(index, 1);
-				return true;
-			}
-		});
-	});
+    $scope.$on("videosource-deleted", function(event, videoSourceId) {
+        $scope.videos.some(function(videoElement, index) {
+            if (videoElement.videoSource.id === videoSourceId) {
+                $scope.videos.splice(index, 1);
+                return true;
+            }
+        });
+    });
 
-	fileInput.addEventListener('change', function(e) {
-		var filesArr = Array.prototype.slice.call(fileInput.files, 0);
-		filesArr.forEach(function (file) {
-			var videoElement;
-			VideoFactory.addVideoSource(file).then(function (videoSource) {
-				videoElement = VideoFactory.createVideoElement(videoSource);
-				$scope.videos.push(videoElement);
-				$scope.$digest();
-				return VideoFactory.attachVideoSource(videoSource, videoElement.id);
-			}).then(function () {
-				videoElement.sourceAttached = true;
-				$scope.$digest();
-			}).then(null, function (error) {
-				//TODO show error on video tag
-				console.error("Error occured when attaching video source", error);
-			});
-		});
+    fileInput.addEventListener('change', function(e) {
+        var filesArr = Array.prototype.slice.call(fileInput.files, 0);
+        filesArr.forEach(function(file) {
+            var videoElement;
+            VideoFactory.addVideoSource(file)
+                .then(function(videoSource) {
+                    videoElement = VideoFactory.createVideoElement(videoSource);
+                    $scope.videos.push(videoElement);
+                    $scope.$digest();
+                    return VideoFactory.attachVideoSource(videoSource, videoElement.id);
+                }).then(function() {
+                    videoElement.sourceAttached = true;
+                    $scope.$digest();
+                }).then(null, function(error) {
+                    //TODO show error on video tag
+                    console.error("Error occured when attaching video source", error);
+                });
+        });
 
-	});
+    });
 
 
-	// This is here just for testing the preview player
-	$scope.previewVideo = () => {
-		var cutsNumber = 5;
-		var cutLength = 2;
-		var allInstructions = RandomVideoGenerator.createVideo($scope.videos, cutsNumber, cutLength);
-		PreviewFactory.setInstructions(allInstructions);
-		$state.go('preview');
-	};
+    // This is here just for testing the preview player
+    $scope.previewVideo = () => {
+        var cutsNumber = 5;
+        var cutLength = 2;
+        var allInstructions = RandomVideoGenerator.createVideo($scope.videos, cutsNumber, cutLength);
+        PreviewFactory.setInstructions(allInstructions);
+        $state.go('preview');
+    };
 
 
 });
-

--- a/browser/js/common/directives/videoplayer/videoplayer.js
+++ b/browser/js/common/directives/videoplayer/videoplayer.js
@@ -31,17 +31,20 @@ app.controller('VideoPlayerCtrl', ($scope, VideoFactory, IdGenerator) => {
 
 
   $scope.prepareVideoElements = function() {
-
+    console.log('preparing video elements')
     if (!$scope.instructions.length) {
       return;
     }
 
+    console.log('I am emitting videoPlayerLoaded with',instructionVideoMap);
     $scope.$emit('videoPlayerLoaded', instructionVideoMap);
 
       var promisedAttachments = [];
       $scope.instructions.forEach((instruction) => {
           var videoId = instructionVideoMap[instruction.id],
               promise = VideoFactory.attachVideoSource(instruction.videoSource, videoId);
+          console.log('I made a promise');
+          console.log(promise);
           promisedAttachments.push(promise);
       });
 

--- a/browser/js/common/directives/videoplayer/videoplayer.js
+++ b/browser/js/common/directives/videoplayer/videoplayer.js
@@ -31,20 +31,16 @@ app.controller('VideoPlayerCtrl', ($scope, VideoFactory, IdGenerator) => {
 
 
   $scope.prepareVideoElements = function() {
-    console.log('preparing video elements')
     if (!$scope.instructions.length) {
       return;
     }
 
-    console.log('I am emitting videoPlayerLoaded with',instructionVideoMap);
     $scope.$emit('videoPlayerLoaded', instructionVideoMap);
 
       var promisedAttachments = [];
       $scope.instructions.forEach((instruction) => {
           var videoId = instructionVideoMap[instruction.id],
               promise = VideoFactory.attachVideoSource(instruction.videoSource, videoId);
-          console.log('I made a promise');
-          console.log(promise);
           promisedAttachments.push(promise);
       });
 
@@ -55,7 +51,6 @@ app.controller('VideoPlayerCtrl', ($scope, VideoFactory, IdGenerator) => {
       // });
 
     var videosArrayLike = $("#" + $scope.videoContainerId).find("video");
-    console.log("$videos", videosArrayLike);
     for (var i = 0; i < videosArrayLike.length; i++) {
       videos[i] = videosArrayLike[i];
       videos[i].index = i;
@@ -193,9 +188,9 @@ app.controller('VideoPlayerCtrl', ($scope, VideoFactory, IdGenerator) => {
       var newIndex;
       for (var i = 0; i < videos.length; i++) {
         // sets indices
-        console.log("$scope.totalCurrentTime", $scope.totalCurrentTime,"timeBefore", videos[i].timeBefore);
+        //console.log("$scope.totalCurrentTime", $scope.totalCurrentTime,"timeBefore", videos[i].timeBefore);
         if ($scope.totalCurrentTime < videos[i].timeBefore) {
-          console.log("$scope.totalCurrentTime", $scope.totalCurrentTime,"timeBefore", videos[i].timeBefore);
+          //console.log("$scope.totalCurrentTime", $scope.totalCurrentTime,"timeBefore", videos[i].timeBefore);
           newIndex = i - 1;
           foundSpot = true;
         } else if (i === videos.length - 1) {

--- a/browser/js/common/factories/RandomVideoGenerator.js
+++ b/browser/js/common/factories/RandomVideoGenerator.js
@@ -45,6 +45,9 @@ app.factory("RandomVideoGenerator", function (FilterFactory, InstructionsFactory
 
 
 	generator.createVideo = function (videoElements, cutsNumber, cutLength) {
+		console.log(videoElements);
+		console.log(cutsNumber);
+		console.log(cutLength);
 		var allInstructions = [];
 		videoElements.forEach(video => {
 			var duration = document.getElementById(video.id).duration;

--- a/browser/js/common/factories/VideoFactory.js
+++ b/browser/js/common/factories/VideoFactory.js
@@ -1,7 +1,10 @@
-app.factory("VideoFactory", function($rootScope, IdGenerator) {
-
+app.factory("VideoFactory", function($rootScope, $http, IdGenerator, AuthService) {
     var vidFactory = {},
         videoSources = {};
+
+    // We'll need to have the user id on hand to figure out the path to uploaded videos in the event of non-webm uploads
+    var userId;
+    AuthService.getLoggedInUser().then(user => userId = user ? user._id : 'anon');
 
     //TODO do ajax polling for uplodaed videos
     //TODO sent ajax call to delete on back-end
@@ -10,6 +13,9 @@ app.factory("VideoFactory", function($rootScope, IdGenerator) {
         this.id = IdGenerator();
         this.sourceAttached = false;
         this.videoSource = videoSource;
+    };
+    VideoElement.prototype.addSource = function (videoSource) {
+    	this.videoSource = videoSource;
     };
 
     var VideoSource = function(fileName, mimeType, arrayBuffer) {
@@ -20,62 +26,74 @@ app.factory("VideoFactory", function($rootScope, IdGenerator) {
         this.objUrls = [];
         // this.mongoId to be assigned after receiving server response
     };
+    VideoSource.prototype.addUrl = function (mongoId, userId) {
+    	this.url = 'api/videos/getconverted/'+userId + '/' + mongoId;
+    };
+    VideoSource.prototype.addMongoId = function(mongoId) {
+        this.mongoId = mongoId;
+        if (!this.arrayBuffer) {
+        	// if no arrayBuffer, must be a converted file we've just gotten back
+        	// it must need a mimeType and a URL too
+        	this.addUrl(mongoId, userId); // var userId is defined early on in the controller
+        	this.mimeType = "video/webm";
+        }
+    };
     VideoSource.prototype.startReading = function(fileName, mimeType, arrayBuffer) {
         this.fileName = fileName;
         this.mimeType = mimeType;
         this.arrayBuffer = arrayBuffer;
     };
-    VideoSource.prototype.addMongoId = function (mongoId) {
-    	this.mongoId = mongoId;
-    };
 
-    var uploadVideoToServer = function(file, localId) {
-        // videoSources[localId] won't be immediately available because the 
-        // request to the server goes out without waiting for the video data 
-        // to get attached to its MediaSource. But it should be ready by the time
-        // this ajax request completes, so we use it in the done function.
-        var reader = new FileReader();
+    var uploadToServer = function(file, videoSrc) {
         var formData = new FormData();
         formData.append("uploadedFile", file);
-        $.ajax({
-            method: 'POST',
-            url: '/api/videos/upload',
-            enctype: 'multipart/form-data',
-            data: formData,
-            processData: false,
-            contentType: false
-        }).done(function(mongoId) {
-            // Just in case, wait for videoSources[localId] to be available (per above comments).
-            // It's always possible that the user has already changed their mind and deleted the
-            // video from their page.
-            var counter = 0;
-            var incrementCounter = function () {counter++; };
-            while (!videoSources[localId] && counter>=20) {
-            	setTimeout(500, incrementCounter); 
-            }
-            if (!videoSources[localId]) {
-            	// If videoSource still not available after 10s, give up. It could have been deleted by user.
-            	console.log('I could not find a videoSource to attach this mongoId to. Letting it go.');
-            }
-            else {
-            	videoSources[localId].addMongoId(mongoId);
-            	console.log('videoSource obj', videoSources[localId]);
-            }
-        }).fail(function (resp) {
-        	console.log('Failed to upload. Server responded with status',resp.status);
-        });
+        var options = {
+            withCredentials: false,
+            // We set Content-Type to undefined because that way the browser automatically fills in 'multipart/form-data'. 
+            // If we manually set it to 'multipart/form-data', it will error because it expects to be told the boundary.
+            headers: {
+                'Content-Type': undefined
+            },
+            // The line below overrides Angular's default transformRequest function, 
+            // which would try to serialize our form data. We want it left intact.
+            transformRequest: angular.identity
+        };
+        return $http.post('/api/videos/upload', formData, options)
+            .then(function(resp) {
+            	// this if statement is for non-webm videos that haven't been added to the sourcevids yet
+            	if (!videoSources[videoSrc.id]) videoSources[videoSrc.id] = videoSrc; 
+                attachMongoId(resp.data, videoSrc.id);
+                return videoSrc;
+            }).catch(err => console.error('something bad happened', err));
+    };
+
+    var attachMongoId = function(mongoId, localId) {
+        // Just in case, wait for videoSources[localId] to be available (per above comments).
+        // It's always possible that the user has already changed their mind and deleted the
+        // video from their page.
+        var counter = 0;
+        var incrementCounter = function() {
+            counter++;
+        };
+        while (!videoSources[localId] && counter >= 20) {
+            setTimeout(500, incrementCounter);
+        }
+        if (!videoSources[localId]) {
+            // If videoSource still not available after 10s, give up. It could have been deleted by user.
+            console.log('I could not find a videoSource to attach this mongoId to. Letting it go.');
+        } else {
+            videoSources[localId].addMongoId(mongoId);
+        }
     };
 
     vidFactory.createVideoElement = function(videoSource) {
         return new VideoElement(videoSource);
     };
 
-    vidFactory.addVideoSource = function(file) {
+    var addWebmVideoSource = function(file, videoSrc, reader) {
+        var reader = new FileReader();
+        // it's webm! we can attach it to the MediaSource right away
         return new Promise(function(resolve, reject) {
-            var reader = new FileReader();
-            // instantiate videoSrc without name, type, or buffer
-            // this way we'll have the id available rightaway
-            var videoSrc = new VideoSource();
             reader.onloadend = function() {
                 // once reader is ready, attach the rest of the video info
                 videoSrc.startReading(file.name, file.type, reader.result);
@@ -83,8 +101,24 @@ app.factory("VideoFactory", function($rootScope, IdGenerator) {
                 resolve(videoSrc);
             };
             reader.readAsArrayBuffer(file);
-            uploadVideoToServer(file, videoSrc.id);
+            uploadToServer(file, videoSrc);
         });
+    };
+
+    var addOtherVideoSource = function(file, videoSrc) {
+        // not webm :( we'll attach it when we get it back from the server
+        return uploadToServer(file, videoSrc).then(function(videoSrc) {
+            videoSources[videoSrc.id] = videoSrc; // add to the video sources list
+            return videoSrc;
+        });
+    };
+
+    vidFactory.addVideoSource = function(file) {
+        // instantiate videoSrc here, add name and contents later
+        // depending on when they're actually available.
+        var videoSrc = new VideoSource();
+        if (file.type === "video/webm") return addWebmVideoSource(file, videoSrc);
+        else return addOtherVideoSource(file, videoSrc);
     };
 
     var mimeTypes = {
@@ -98,8 +132,7 @@ app.factory("VideoFactory", function($rootScope, IdGenerator) {
         'video/webm': 'video/webm; codecs="vp8, vorbis"'
     };
 
-
-    vidFactory.attachVideoSource = function(videoSource, videoElementId) {
+    var attachBufferVideoSource = function(videoSource, videoElementId) {
         return new Promise(function(resolve, reject) {
             var mediaSource = new MediaSource();
             mediaSource.addEventListener("sourceopen", function() {
@@ -120,11 +153,60 @@ app.factory("VideoFactory", function($rootScope, IdGenerator) {
             });
             var objUrl = window.URL.createObjectURL(mediaSource);
             var video = document.getElementById(videoElementId);
-            // console.log("videoElementId", videoElementId);
             video.src = objUrl;
             video.reelCoolVideoSourceId = videoSource.id;
             videoSource.objUrls.push(objUrl);
         });
+    };
+
+    var attachUrlVideoSource = function(videoSource, videoElementId) {
+        return new Promise(function(resolve, reject) {
+            var mediaSource = new MediaSource();
+            mediaSource.addEventListener("sourceopen", function() {
+                var sourceBuffer = mediaSource.addSourceBuffer(mimeTypes[videoSource.mimeType]);
+                sourceBuffer.addEventListener('updateend', function(_) {
+                    try {
+                        mediaSource.endOfStream();
+                        resolve();
+                    } catch (error) {
+                        return reject(error);
+                    }
+                });
+                var xhr = new XMLHttpRequest();
+                xhr.open('GET', videoSource.url, true);
+                xhr.responseType = 'arraybuffer';
+                xhr.onload = function(e) {
+                    if (xhr.status !== 200) {
+                        console.error("Failed to download video data");
+                    } else {
+                        var arr = new Uint8Array(xhr.response);
+                        videoSource.arrayBuffer = arr;
+                        try {
+	                        sourceBuffer.appendBuffer(videoSource.arrayBuffer);                        	
+                        }
+                        catch (e) { 
+                        	console.error('error appending buffer', e); 
+                        	return reject(e); 
+                        }
+                    }
+                };
+                xhr.send();
+            });
+            var objUrl = window.URL.createObjectURL(mediaSource);
+            var video = document.getElementById(videoElementId);
+            video.src = objUrl;
+            video.reelCoolVideoSourceId = videoSource.id;
+            videoSource.objUrls.push(objUrl);
+        });
+    };
+
+    vidFactory.attachVideoSource = function(videoSource, videoElementId) {
+        if (videoSource.arrayBuffer) {
+            return attachBufferVideoSource(videoSource, videoElementId);
+        }
+        if (videoSource.url) {
+            return attachUrlVideoSource(videoSource, videoElementId);
+        }
     };
 
 

--- a/browser/js/common/factories/VideoFactory.js
+++ b/browser/js/common/factories/VideoFactory.js
@@ -204,6 +204,7 @@ app.factory("VideoFactory", function($rootScope, $http, IdGenerator, AuthService
     };
 
     vidFactory.attachVideoSource = function(videoSource, videoElementId) {
+        console.log('attaching video source');
         console.log(videoSource);
         console.log(videoElementId);
         if (videoSource.arrayBuffer) {

--- a/browser/js/common/factories/VideoFactory.js
+++ b/browser/js/common/factories/VideoFactory.js
@@ -16,7 +16,6 @@ app.factory("VideoFactory", function($rootScope, $http, IdGenerator, AuthService
     VideoElement.prototype.addSource = function (videoSource, instructions) {
     	this.videoSource = videoSource;
         this.instructions = instructions || InstructionsFactory.generate(this.videoSource);
-        console.log('my source was added',this.videoSource);
     };
 
     var VideoSource = function(fileName, mimeType, arrayBuffer) {
@@ -204,9 +203,6 @@ app.factory("VideoFactory", function($rootScope, $http, IdGenerator, AuthService
     };
 
     vidFactory.attachVideoSource = function(videoSource, videoElementId) {
-        console.log('attaching video source');
-        console.log(videoSource);
-        console.log(videoElementId);
         if (videoSource.arrayBuffer) {
             return attachBufferVideoSource(videoSource, videoElementId);
         }

--- a/browser/js/common/factories/VideoFactory.js
+++ b/browser/js/common/factories/VideoFactory.js
@@ -9,14 +9,14 @@ app.factory("VideoFactory", function($rootScope, $http, IdGenerator, AuthService
     //TODO do ajax polling for uploaded videos
     //TODO sent ajax call to delete on back-end
 
-    var VideoElement = function(videoSource, instructions) {
+    var VideoElement = function() {
         this.id = IdGenerator();
         this.sourceAttached = false;
-        this.videoSource = videoSource;
-        this.instructions = instructions || InstructionsFactory.generate(this.videoSource);
     };
-    VideoElement.prototype.addSource = function (videoSource) {
+    VideoElement.prototype.addSource = function (videoSource, instructions) {
     	this.videoSource = videoSource;
+        this.instructions = instructions || InstructionsFactory.generate(this.videoSource);
+        console.log('my source was added',this.videoSource);
     };
 
     var VideoSource = function(fileName, mimeType, arrayBuffer) {
@@ -204,6 +204,8 @@ app.factory("VideoFactory", function($rootScope, $http, IdGenerator, AuthService
     };
 
     vidFactory.attachVideoSource = function(videoSource, videoElementId) {
+        console.log(videoSource);
+        console.log(videoElementId);
         if (videoSource.arrayBuffer) {
             return attachBufferVideoSource(videoSource, videoElementId);
         }

--- a/browser/js/common/factories/VideoFactory.js
+++ b/browser/js/common/factories/VideoFactory.js
@@ -1,121 +1,146 @@
-app.factory("VideoFactory", function ($rootScope, IdGenerator) {
+app.factory("VideoFactory", function($rootScope, IdGenerator) {
 
-	var vidFactory = {},
-		videoSources = {};
+    var vidFactory = {},
+        videoSources = {};
+
+    //TODO do ajax polling for uplodaed videos
+    //TODO sent ajax call to delete on back-end
+
+    var VideoElement = function(videoSource) {
+        this.id = IdGenerator();
+        this.sourceAttached = false;
+        this.videoSource = videoSource;
+    };
+
+    var VideoSource = function(fileName, mimeType, arrayBuffer) {
+        this.id = IdGenerator();
+        this.fileName = fileName;
+        this.mimeType = mimeType;
+        this.arrayBuffer = arrayBuffer;
+        this.objUrls = [];
+        // this.mongoId to be assigned after receiving server response
+    };
+    VideoSource.prototype.startReading = function(fileName, mimeType, arrayBuffer) {
+        this.fileName = fileName;
+        this.mimeType = mimeType;
+        this.arrayBuffer = arrayBuffer;
+    };
+    VideoSource.prototype.addMongoId = function (mongoId) {
+    	this.mongoId = mongoId;
+    };
+
+    var uploadVideoToServer = function(file, localId) {
+        // videoSources[localId] won't be immediately available because the 
+        // request to the server goes out without waiting for the video data 
+        // to get attached to its MediaSource. But it should be ready by the time
+        // this ajax request completes, so we use it in the done function.
+        var reader = new FileReader();
+        var formData = new FormData();
+        formData.append("uploadedFile", file);
+        $.ajax({
+            method: 'POST',
+            url: '/api/videos/upload',
+            enctype: 'multipart/form-data',
+            data: formData,
+            processData: false,
+            contentType: false
+        }).done(function(mongoId) {
+            // Just in case, wait for videoSources[localId] to be available (per above comments).
+            // It's always possible that the user has already changed their mind and deleted the
+            // video from their page.
+            var counter = 0;
+            var incrementCounter = function () {counter++; };
+            while (!videoSources[localId] && counter>=20) {
+            	setTimeout(500, incrementCounter); 
+            }
+            if (!videoSources[localId]) {
+            	// If videoSource still not available after 10s, give up. It could have been deleted by user.
+            	console.log('I could not find a videoSource to attach this mongoId to. Letting it go.');
+            }
+            else {
+            	videoSources[localId].addMongoId(mongoId);
+            	console.log('videoSource obj', videoSources[localId]);
+            }
+        }).fail(function (resp) {
+        	console.log('Failed to upload. Server responded with status',resp.status);
+        });
+    };
+
+    vidFactory.createVideoElement = function(videoSource) {
+        return new VideoElement(videoSource);
+    };
+
+    vidFactory.addVideoSource = function(file) {
+        return new Promise(function(resolve, reject) {
+            var reader = new FileReader();
+            // instantiate videoSrc without name, type, or buffer
+            // this way we'll have the id available rightaway
+            var videoSrc = new VideoSource();
+            reader.onloadend = function() {
+                // once reader is ready, attach the rest of the video info
+                videoSrc.startReading(file.name, file.type, reader.result);
+                videoSources[videoSrc.id] = videoSrc;
+                resolve(videoSrc);
+            };
+            reader.readAsArrayBuffer(file);
+            uploadVideoToServer(file, videoSrc.id);
+        });
+    };
+
+    var mimeTypes = {
+        //'video/mp4': 'video/mp4; codecs="avc1.64001F, mp4a.40.2"',
+        //'video/mp4': 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"',
+        //'video/mp4':  'video/mp4; codecs="avc1.58A01E, mp4a.40.2"',
+        //'video/mp4':  'video/mp4; codecs="avc1.4D401E, mp4a.40.2"',
+        //'video/mp4':  'video/mp4; codecs="avc1.64001E, mp4a.40.2"',
+        //'video/mp4':  'video/mp4; codecs="mp4v.20.8, mp4a.40.2"',
+        //'video/mp4':  'video/mp4; codecs="mp4v.20.240, mp4a.40.2"',
+        'video/webm': 'video/webm; codecs="vp8, vorbis"'
+    };
 
 
-	//TODO do ajax polling for uplodaed videos
-	//TODO sent ajax call to delete on back-end
-
-	var VideoElement = function (videoSource) {
-		this.id = IdGenerator();
-		this.sourceAttached = false;
-		this.videoSource = videoSource;
-	};
-
-
-	var VideoSource = function (fileName, mimeType, arrayBuffer) {
-		this.id = IdGenerator();
-		this.fileName = fileName;
-		this.mimeType = mimeType;
-		this.arrayBuffer = arrayBuffer;
-		this.objUrls = [];
-	};
-
-
-	var uploadVideoToServer = function(file){
-		var reader = new FileReader();
-		var formData = new FormData();
-		formData.append("uploadedFile",file);
-
-		$.ajax({
-				method: 'POST',
-				url: '/api/videos/upload',
-				enctype:'multipart/form-data',
-				data: formData,
-				processData:false,
-				contentType:false
-			}).done(function(data){
-				console.log('done!');
-		});
-	};
+    vidFactory.attachVideoSource = function(videoSource, videoElementId) {
+        return new Promise(function(resolve, reject) {
+            var mediaSource = new MediaSource();
+            mediaSource.addEventListener("sourceopen", function() {
+                var sourceBuffer = mediaSource.addSourceBuffer(mimeTypes[videoSource.mimeType]);
+                sourceBuffer.addEventListener('updateend', function(_) {
+                    try {
+                        mediaSource.endOfStream();
+                        resolve();
+                    } catch (error) {
+                        return reject(error);
+                    }
+                });
+                try {
+                    sourceBuffer.appendBuffer(videoSource.arrayBuffer);
+                } catch (error) {
+                    return reject(error);
+                }
+            });
+            var objUrl = window.URL.createObjectURL(mediaSource);
+            var video = document.getElementById(videoElementId);
+            // console.log("videoElementId", videoElementId);
+            video.src = objUrl;
+            video.reelCoolVideoSourceId = videoSource.id;
+            videoSource.objUrls.push(objUrl);
+        });
+    };
 
 
-	vidFactory.createVideoElement = function (videoSource) {
-		return new VideoElement(videoSource);
-	};
+    vidFactory.deleteVideoSource = function(videoSourceId) {
+        var videoSource = videoSources[videoSourceId];
 
+        $rootScope.$broadcast("videosource-deleted", videoSourceId);
 
-	vidFactory.addVideoSource = function(file) {
-		return new Promise(function (resolve, reject) {
-			var reader = new FileReader();
-			reader.onloadend = function() {
-				var videoSrc = new VideoSource(file.name, file.type, reader.result);
-				videoSources[videoSrc.id] = videoSrc;
-				resolve(videoSrc);
-			};
-			reader.readAsArrayBuffer(file);
-			uploadVideoToServer(file);
-		});
-	};
+        videoSource.objUrls.forEach(window.URL.revokeObjectURL);
+        delete videoSource.arrayBuffer;
 
-	var mimeTypes = {
-		//'video/mp4': 'video/mp4; codecs="avc1.64001F, mp4a.40.2"',
-		//'video/mp4': 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"',
-		//'video/mp4':  'video/mp4; codecs="avc1.58A01E, mp4a.40.2"',
-		//'video/mp4':  'video/mp4; codecs="avc1.4D401E, mp4a.40.2"',
-		//'video/mp4':  'video/mp4; codecs="avc1.64001E, mp4a.40.2"',
-		//'video/mp4':  'video/mp4; codecs="mp4v.20.8, mp4a.40.2"',
-		//'video/mp4':  'video/mp4; codecs="mp4v.20.240, mp4a.40.2"',
-		'video/webm': 'video/webm; codecs="vp8, vorbis"'
-	};
+        //TODO sent ajax call to delete on back-end
 
+        console.log("video source terminated!");
+    };
 
-	vidFactory.attachVideoSource = function (videoSource, videoElementId) {
-		return new Promise(function (resolve, reject) {
-			var mediaSource = new MediaSource();
-			mediaSource.addEventListener("sourceopen", function () {
-				var sourceBuffer = mediaSource.addSourceBuffer(mimeTypes[videoSource.mimeType]);
-				sourceBuffer.addEventListener('updateend', function(_) {
-					try {
-						mediaSource.endOfStream();
-						resolve();
-					} catch (error) {
-						return reject(error);
-					}
-				});
-				try {
-					sourceBuffer.appendBuffer(videoSource.arrayBuffer);
-				} catch (error) {
-					return reject(error);
-				}
-			});
-			var objUrl = window.URL.createObjectURL(mediaSource);
-			var video = document.getElementById(videoElementId);
-			console.log("videoElementId", videoElementId);
-			video.src = objUrl;
-			video.reelCoolVideoSourceId = videoSource.id;
-			videoSource.objUrls.push(objUrl);
-		});
-	};
-
-
-	vidFactory.deleteVideoSource = function (videoSourceId) {
-		var videoSource = videoSources[videoSourceId];
-
-		$rootScope.$broadcast("videosource-deleted", videoSourceId);
-
-		videoSource.objUrls.forEach(window.URL.revokeObjectURL);
-		delete videoSource.arrayBuffer;
-
-		//TODO sent ajax call to delete on back-end
-
-		console.log("video source terminated!");
-	};
-
-	return vidFactory;
+    return vidFactory;
 
 });
-
-
-

--- a/browser/js/playground/playground.js
+++ b/browser/js/playground/playground.js
@@ -20,6 +20,8 @@ app.controller('PlaygroundCtrl', ($scope, FilterFactory, InstructionsFactory, Pr
   });
 
   $scope.$on('videoPlayerLoaded', (e, instructionVideoMap) => {
+    console.log('I heard videoPlayerLoaded',instructionVideoMap);
+    console.log('here is $scope.instructions[0]',$scope.instructions[0]);
     video = document.getElementById(instructionVideoMap[$scope.instructions[0].id]);
     $video = $(video);
     initFilters();

--- a/browser/js/playground/playground.js
+++ b/browser/js/playground/playground.js
@@ -20,8 +20,6 @@ app.controller('PlaygroundCtrl', ($scope, FilterFactory, InstructionsFactory, Pr
   });
 
   $scope.$on('videoPlayerLoaded', (e, instructionVideoMap) => {
-    console.log('I heard videoPlayerLoaded',instructionVideoMap);
-    console.log('here is $scope.instructions[0]',$scope.instructions[0]);
     video = document.getElementById(instructionVideoMap[$scope.instructions[0].id]);
     $video = $(video);
     initFilters();

--- a/browser/js/preview/preview.js
+++ b/browser/js/preview/preview.js
@@ -2,7 +2,7 @@ app.config(($stateProvider) => {
 
     $stateProvider.state('preview', {
         url: '/preview',
-        templateUrl: 'js/preview/preview-dialog.html',
+        templateUrl: 'js/preview/preview.html',
         controller: ($scope, PreviewFactory) => {
           $scope.instructions = PreviewFactory.getInstructions();
           console.log("previewer got instructions", $scope.instructions);

--- a/server/app/routes/videos/index.js
+++ b/server/app/routes/videos/index.js
@@ -118,10 +118,14 @@ router.post('/makeit', function(req, res) {
         return fs.readdirAsync(stagingAreaPath)
             .then(arrayOfFiles => Promise.map(arrayOfFiles, function (file) { return fs.unlinkAsync(path.join(stagingAreaPath, file)); }));
     }
-
     
 });
 
+router.get('/getconverted/:userId/:videoId',function (req,res){
+    var filename = req.params.videoId+'.webm';
+    var pathToVid = path.join(filesPath, req.params.userId, 'uploaded', filename);
+    fs.createReadStream(pathToVid).pipe(res);
+});
 
 router.get('/download/:videoId',function (req,res) {
     res.setHeader('Content-disposition', 'attachment; filename=reelcoolmovie.mp4');

--- a/server/db/models/user.js
+++ b/server/db/models/user.js
@@ -67,16 +67,22 @@ schema.method('correctPassword', function (candidatePassword) {
 schema.post('save',function (user) {
     var pathToUserDir = path.join(__dirname,"..","..","files",user._id.toString());
     var userSubDirs = ['created', 'staging', 'uploaded', 'temp'];
+    var makeSubDirs;
     fs.statAsync(pathToUserDir) // will err if the directory doesn't exist
         .then(
-            stats => console.log(stats), // no need to make dirs, bc user and his/her dirs exist already
-            err => fs.mkdirAsync(pathToUserDir) // will create the user's directory
-            )
+            stats => console.log('user dir already exists'), 
+            function (err) { 
+                makeSubDirs=true; 
+                return fs.mkdirAsync(pathToUserDir); 
+            } // will create the user's directory
+        )
         .then(
-            () => Promise.map(userSubDirs, subDir => fs.mkdirAsync(path.join(pathToUserDir,subDir))), 
+            function () {
+                if (makeSubDirs) return Promise.map(userSubDirs, subDir => fs.mkdirAsync(path.join(pathToUserDir,subDir)));
+            }, 
             (err) => console.error(err)
-            )
+        )
         .catch(err => console.error(err));
-})
+});
 
 mongoose.model('User', schema);


### PR DESCRIPTION
- each video uploaded gets its mongoId attached to once it's available
- webm files get embedded in the browser immediately, non-webm files get converted first. then their video source pulls from the url to the converted video.
- there are basically two chains of events for uploads: one for webm videos, and one for non-webm. 
- I tried to keep repetition between those two to a minimum, but it could probably be even DRYer. It's ready to be used though.
