### PR TITLE
updated preview player. removed whitespace above slider. gray overlay…

### DIFF
--- a/browser/js/common/directives/modalwindow/modalwindow.html
+++ b/browser/js/common/directives/modalwindow/modalwindow.html
@@ -1,11 +1,9 @@
-<div class='ng-modal' ng-if='show'>
-  <div class='ng-modal-overlay' ng-click='hideModal()'></div>
-  <div class='ng-modal-dialog' ng-style='dialogStyle'>
-    <div class='ng-modal-close' ng-click='hideModal()'><i class="zmdi zmdi-close "></i></div>
-    <div class='ng-modal-dialog-content'>
-        <div class="col-sm-12">
-          <video-player audioenabled="true" width="100" height="100" instructions="instructions" video-player-id="'previewer'" style="display:inline-block"></video-player>
-        </div>
-    </div>
+<div class='ng-modal-overlay' ng-click='hideModal()' ng-if='show'></div>
+<div class='ng-modal-dialog' ng-style='dialogStyle' ng-if='show'>
+  <div class='ng-modal-close' ng-click='hideModal()'><i class="zmdi zmdi-close "></i></div>
+  <div class='ng-modal-dialog-content'>
+      <div class="col-sm-12">
+        <video-player audioenabled="true" width="100" height="100" instructions="instructions" video-player-id="'previewer'" style="display:inline-block"></video-player>
+      </div>
   </div>
 </div>

--- a/browser/js/common/directives/modalwindow/modalwindow.js
+++ b/browser/js/common/directives/modalwindow/modalwindow.js
@@ -12,7 +12,6 @@ app.directive("modalDialog", () => {
       $scope.$on('toggleModal', (e, args) => {
         //this should be the only place where "show" is toggled
         //only the modal directly affects whether it should be shown
-        console.log("modal toggles itself to", args.show)
         $scope.show = args.show;
         $scope.instructions = InstructionsFactory.get();
       })

--- a/browser/js/common/directives/videoplayer/videoplayer.html
+++ b/browser/js/common/directives/videoplayer/videoplayer.html
@@ -3,23 +3,9 @@
   	<div class="emptyVideo" style="width: {{width}}%; min-height: 400px; max-height: 40%;" ng-hide="instructions.length">
     </div>
     <div ng-repeat="instruction in instructions" class="playingVideo" ng-show="currentClip===$index">
-      <video width="{{width}}%" height="550px" id="{{getIdForVideo(instruction.id)}}" class='box playgroundvid' style="-webkit-filter: {{instruction.filterString}}" preload>
+      <video width="{{width}}%" id="{{getIdForVideo(instruction.id)}}" class='box playgroundvid' style="-webkit-filter: {{instruction.filterString}}" preload>
       </video>
     </div>
-
-<!-- <pre>
-audio config:
-{{audioObj}}
-
-currentAudio:
-{{currentAudio}}
-{{currentAudio.domElement.volume}}
-instructions: {{instructions | json}}
-totalEndTime: {{totalEndTime}}
-totalCurrentTime: {{totalCurrentTime}}
-</pre> -->
-
-
     <time-slider ng-show="instructions.length" id="slider" moving-time="totalCurrentTime" start-time="getCurrentStartTime()" end-time="totalEndTime" width="width"></time-slider>
   </div>
 

--- a/browser/scss/main.scss
+++ b/browser/scss/main.scss
@@ -3,7 +3,16 @@ $backURL: url('http://subtlepatterns2015.subtlepatterns.netdna-cdn.com/patterns/
 
 
 * {
-  box-sizing: border-box;
+  //box-sizing: border-box;
+}
+
+html{
+  height: 100%;
+
+  body {
+    height: 100%;
+    min-height: 100%;
+  }
 }
 
 @mixin clearfix {
@@ -75,48 +84,6 @@ body {
   font-family: 'Montserrat';
   /*font-size: 30px;*/
 }
-.ng-modal-overlay {
-  /* A dark translucent div that covers the whole screen */
-  position:absolute;
-  z-index:9999;
-  top:0;
-  left:0;
-  width:100%;
-  height:100%;
-  background-color:#000000;
-  opacity: 0.8;
-}
-.ng-modal-dialog {
-  /* A centered div above the overlay with a box shadow. */
-  z-index:10000;
-  position: absolute;
-  width: 50%; /* Default */
-
-  /* Center the dialog */
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  -webkit-transform: translate(-50%, -50%);
-  -moz-transform: translate(-50%, -50%);
-
-  background-color: #fff;
-  box-shadow: 4px 4px 80px #000;
-}
-.ng-modal-dialog-content {
-  padding:10px;
-  text-align: left;
-}
-.ng-modal-close {
-  position: absolute;
-  top: 3px;
-  right: 5px;
-  padding: 5px;
-  cursor: pointer;
-  font-size: 120%;
-  display: inline-block;
-  font-weight: bold;
-  font-family: 'arial', 'sans-serif';
-}
 
 .brand {
   font-family: "Lobster";
@@ -167,3 +134,4 @@ md-virtual-repeat-container {
 @import 'login/main';
 @import 'video/main';
 @import 'splash/main';
+@import 'modalwindow/main';

--- a/browser/scss/modalwindow/main.scss
+++ b/browser/scss/modalwindow/main.scss
@@ -1,0 +1,48 @@
+modal-dialog {
+  height: 100%;
+  width: 100%;
+}
+
+.ng-modal-overlay {
+  /* A dark translucent div that covers the whole screen */
+  position:fixed;
+  z-index:9999;
+  top:0;
+  left:0;
+  width:100%;
+  height: 100%;
+  background-color:#000000;
+  opacity: 0.8;
+  overflow: auto;
+}
+.ng-modal-dialog {
+  /* A centered div above the overlay with a box shadow. */
+  z-index:10000;
+  position: absolute;
+  width: 50%; /* Default */
+
+  /* Center the dialog */
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
+  -moz-transform: translate(-50%, -50%);
+
+  background-color: #fff;
+  box-shadow: 4px 4px 80px #000;
+}
+.ng-modal-dialog-content {
+  padding:10px;
+  text-align: left;
+}
+.ng-modal-close {
+  position: absolute;
+  top: 3px;
+  right: 5px;
+  padding: 5px;
+  cursor: pointer;
+  font-size: 120%;
+  display: inline-block;
+  font-weight: bold;
+  font-family: 'arial', 'sans-serif';
+}

--- a/server/app/configure/index.js
+++ b/server/app/configure/index.js
@@ -15,7 +15,7 @@ module.exports = function (app) {
     require('./parsing-middleware')(app);
 
     // Logging middleware, set as application
-    // variable inside of server/app/configure/app-variables.js
+    // variable inside of server/app/conf igure/app-variables.js
     app.use(app.getValue('log'));
 
     require('./authentication')(app);

--- a/server/app/views/index.html
+++ b/server/app/views/index.html
@@ -27,7 +27,7 @@
 </head>
 <body ng-app="FullstackGeneratedApp">
     <div>
-      <modal-dialog show="modalShown" width='700' height='400'>
+      <modal-dialog show="modalShown">
       </modal-dialog>
       <ui-view></ui-view>
     </div>


### PR DESCRIPTION
… covers whole screen

The position of the gray translucent overlay is "fixed" now so it covers the entire screen. I tried putting "position: fixed" on html or body instead, but that makes the scrollbar of the page go away and you can't scroll. 

Removed unnecessary width and height settings for the modal window. 

Removed height setting of video player that was causing the white space gap.
